### PR TITLE
Pass forward request error code on default handle error exception

### DIFF
--- a/src/MakesHttpRequests.php
+++ b/src/MakesHttpRequests.php
@@ -6,7 +6,6 @@ use Psr\Http\Message\ResponseInterface;
 use PerfectWorkout\ActiveCampaign\Exceptions\NotFoundException;
 use PerfectWorkout\ActiveCampaign\Exceptions\ValidationException;
 use PerfectWorkout\ActiveCampaign\Exceptions\FailedActionException;
-use Exception;
 
 /**
  * Class MakesHttpRequests.
@@ -105,7 +104,7 @@ trait MakesHttpRequests
         );
 
         if (! in_array($response->getStatusCode(), [200, 201])) {
-            $this->handleRequestError($response);
+            return $this->handleRequestError($response);
         }
 
         $responseBody = (string) $response->getBody();
@@ -114,22 +113,29 @@ trait MakesHttpRequests
     }
 
     /**
-     * @param  ResponseInterface $response
+     * @param  \Psr\Http\Message\ResponseInterface $response
      *
-     * @throws ValidationException
-     * @throws NotFoundException
-     * @throws FailedActionException
-     * @throws Exception
+     * @throws \PerfectWorkout\ActiveCampaign\Exceptions\ValidationException
+     * @throws \PerfectWorkout\ActiveCampaign\Exceptions\NotFoundException
+     * @throws \PerfectWorkout\ActiveCampaign\Exceptions\FailedActionException
+     * @throws \Exception
      *
      * @return void
      */
-    private function handleRequestError(ResponseInterface $response): void
+    private function handleRequestError(ResponseInterface $response)
     {
-        match ($response->getStatusCode()) {
-            422 => throw new ValidationException(json_decode((string) $response->getBody(), true)),
-            404 => throw new NotFoundException(),
-            400 => throw new FailedActionException((string) $response->getBody()),
-            default => throw new Exception((string) $response->getBody(), $response->getStatusCode()),
-        };
+        if ($response->getStatusCode() == 422) {
+            throw new ValidationException(json_decode((string) $response->getBody(), true));
+        }
+
+        if ($response->getStatusCode() == 404) {
+            throw new NotFoundException();
+        }
+
+        if ($response->getStatusCode() == 400) {
+            throw new FailedActionException((string) $response->getBody());
+        }
+
+        throw new \Exception((string) $response->getBody(), $response->getStatusCode());
     }
 }

--- a/src/MakesHttpRequests.php
+++ b/src/MakesHttpRequests.php
@@ -6,6 +6,7 @@ use Psr\Http\Message\ResponseInterface;
 use PerfectWorkout\ActiveCampaign\Exceptions\NotFoundException;
 use PerfectWorkout\ActiveCampaign\Exceptions\ValidationException;
 use PerfectWorkout\ActiveCampaign\Exceptions\FailedActionException;
+use Exception;
 
 /**
  * Class MakesHttpRequests.
@@ -113,29 +114,23 @@ trait MakesHttpRequests
     }
 
     /**
-     * @param  \Psr\Http\Message\ResponseInterface $response
+     * @param  Psr\Http\Message\ResponseInterface $response
      *
-     * @throws \PerfectWorkout\ActiveCampaign\Exceptions\ValidationException
-     * @throws \PerfectWorkout\ActiveCampaign\Exceptions\NotFoundException
-     * @throws \PerfectWorkout\ActiveCampaign\Exceptions\FailedActionException
-     * @throws \Exception
+     * @throws PerfectWorkout\ActiveCampaign\Exceptions\ValidationException
+     * @throws PerfectWorkout\ActiveCampaign\Exceptions\NotFoundException
+     * @throws PerfectWorkout\ActiveCampaign\Exceptions\FailedActionException
+     * @throws Exception
+     * @throws Exception
      *
      * @return void
      */
-    private function handleRequestError(ResponseInterface $response)
+    private function handleRequestError(ResponseInterface $response): void
     {
-        if ($response->getStatusCode() == 422) {
-            throw new ValidationException(json_decode((string) $response->getBody(), true));
-        }
-
-        if ($response->getStatusCode() == 404) {
-            throw new NotFoundException();
-        }
-
-        if ($response->getStatusCode() == 400) {
-            throw new FailedActionException((string) $response->getBody());
-        }
-
-        throw new \Exception((string) $response->getBody());
+        match ($response->getStatusCode()) {
+            422 => throw new ValidationException(json_decode((string) $response->getBody(), true)),
+            404 => throw new NotFoundException(),
+            400 => throw new FailedActionException((string) $response->getBody()),
+            default => throw new Exception((string) $response->getBody(), $response->getStatusCode()),
+        };
     }
 }

--- a/src/MakesHttpRequests.php
+++ b/src/MakesHttpRequests.php
@@ -105,7 +105,7 @@ trait MakesHttpRequests
         );
 
         if (! in_array($response->getStatusCode(), [200, 201])) {
-            return $this->handleRequestError($response);
+            $this->handleRequestError($response);
         }
 
         $responseBody = (string) $response->getBody();
@@ -114,12 +114,11 @@ trait MakesHttpRequests
     }
 
     /**
-     * @param  Psr\Http\Message\ResponseInterface $response
+     * @param  ResponseInterface $response
      *
-     * @throws PerfectWorkout\ActiveCampaign\Exceptions\ValidationException
-     * @throws PerfectWorkout\ActiveCampaign\Exceptions\NotFoundException
-     * @throws PerfectWorkout\ActiveCampaign\Exceptions\FailedActionException
-     * @throws Exception
+     * @throws ValidationException
+     * @throws NotFoundException
+     * @throws FailedActionException
      * @throws Exception
      *
      * @return void

--- a/src/MakesHttpRequests.php
+++ b/src/MakesHttpRequests.php
@@ -136,6 +136,7 @@ trait MakesHttpRequests
             throw new FailedActionException((string) $response->getBody());
         }
 
+        //adding the status code allows us to custom handle RateLimit errors
         throw new \Exception((string) $response->getBody(), $response->getStatusCode());
     }
 }


### PR DESCRIPTION
draft because i wanted to know what the conventions were committing to this repo if there were any different guidelines. Like should have not adjusted it for the PSR warnings ?

also i could have solved this by either just adding the code to the default exception like i did here, or added a new exception handler for rate limiting error since that error is not being caught differently in the current function and added that to one of exception cases. I chose the error code into the default because seemed less degree of a change but switching the new exception type should be quick adjustment if thats preferred

this branch needs to be committed before i can PR the main Rate limiting code for Job workers